### PR TITLE
Swap out pystac recursion, lint recursively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 
 
 ## [Unreleased]
+### Added
+- recursive mode lints assets https://github.com/stac-utils/stac-check/pull/84
+### Changed
+- recursive mode swaps pystac for stac-validator https://github.com/stac-utils/stac-check/pull/84
 ### Fixed
 - fix catalog file name check https://github.com/stac-utils/stac-check/pull/83
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,13 @@ stac-check: STAC spec validaton and linting tool
 
 Please upgrade from version 0.9.0 to version 1.0.0!
 
-Validator: stac-validator
-    Recursive: Validate all assets in a collection or catalog
+Validator: stac-validator 3.1.0
+
+
+Recursive: Validate all assets in a collection or catalog
+Max-depth = None
+-------------------------
+Asset 1 Validated: https://raw.githubusercontent.com/stac-utils/pystac/main/tests/data-files/examples/0.9.0/collection-spec/examples/landsat-collection.json
 
 Valid COLLECTION: True
 
@@ -63,12 +68,17 @@ STAC Best Practices:
 
     Links in catalogs and collections should always have a 'title' field
 
-
-Recursive validation has failed!
-Recursive validation error message: 
-    Exception Could not read uri https://landsat-stac.s3.amazonaws.com/landsat-8-l1/paths/catalog.json
-
 This object has 4 links
+
+-------------------------
+Asset 2 Validated: https://landsat-stac.s3.amazonaws.com/landsat-8-l1/paths/catalog.json
+
+Valid: False
+Schemas validated: 
+    https://cdn.staclint.com/v0.9.0/collection.json
+Error Type: JSONDecodeError
+Error Message: Expecting value: line 1 column 1 (char 0)
+-------------------------
 ```
 
 ``` stac-check sample_files/0.9.0/landsat8-sample.json```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ stac-check: STAC spec validaton and linting tool
 
 Please upgrade from version 0.9.0 to version 1.0.0!
 
-Validator: pystac 1.1.0
+Validator: stac-validator
     Recursive: Validate all assets in a collection or catalog
 
 Valid COLLECTION: True

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ or for local development
 Usage: stac-check [OPTIONS] FILE
 
 Options:
-  --version        Show the version and exit.
-  -l, --links      Validate links for format and response.
-  -a, --assets     Validate assets for format and response.
-  -r, --recursive  Validate all assets in a collection or catalog.
-  --help           Show this message and exit.
+  --version                Show the version and exit.
+  -l, --links              Validate links for format and response.
+  -a, --assets             Validate assets for format and response.
+  -r, --recursive INTEGER  Maximum depth to traverse when using recursion.
+  --help                   Show this message and exit.
 ```
 ---
 ### Docker  

--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ Options:
   --version                Show the version and exit.
   -l, --links              Validate links for format and response.
   -a, --assets             Validate assets for format and response.
-  -r, --recursive INTEGER  Maximum depth to traverse when using recursion.
-  --help                   Show this message and exit.
+  -m, --max-depth INTEGER  Maximum depth to traverse when recursing. Omit this
+                           argument to get full recursion. Ignored if
+                           `recursive == False`.
+  -r, --recursive          Recursively validate all related stac objects.
+  --help                   Show this message and exit.               Show this message and exit.
 ```
 ---
 ### Docker  

--- a/sample_files/1.0.0/catalog-with-bad-item.json
+++ b/sample_files/1.0.0/catalog-with-bad-item.json
@@ -1,0 +1,31 @@
+{
+  "id": "examples",
+  "type": "Catalog",
+  "title": "Example Catalog",
+  "stac_version": "1.0.0",
+  "description": "This is a valid catalog with links to one valid item and one invalid item.",
+  "links": [
+    {
+      "rel": "root",
+      "href": "./catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "./bad-item.json",
+      "type": "application/json",
+      "title": "Invalid item"
+    },
+    {
+      "rel": "item",
+      "href": "./collectionless-item.json",
+      "type": "application/json",
+      "title": "Collection with no items (standalone)"
+    },
+    {
+      "rel": "self",
+      "href": "https://raw.githubusercontent.com/radiantearth/stac-spec/v1.0.0/examples/catalog.json",
+      "type": "application/json"
+    }
+  ]
+}

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(exclude=("tests",)),
     include_package_data=True,
     install_requires=[
-        "click>=7.1.2",
+        "click>=8.0.0",
         "requests>=2.19.1",
         "jsonschema>=3.1.2b0",
         "pytest",

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "stac-validator>=3.0.0",
         "PyYAML",
         "python-dotenv",
+        "types-setuptools",
     ],
     entry_points={
         'console_scripts': ['stac-check=stac_check.cli:main']

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     packages=find_packages(exclude=("tests",)),
     include_package_data=True,
     install_requires=[
-        "pystac[validation]>=1.1.0",
         "click>=7.1.2",
         "requests>=2.19.1",
         "jsonschema>=3.1.2b0",

--- a/stac_check/cli.py
+++ b/stac_check/cli.py
@@ -1,5 +1,6 @@
 import click
 from .lint import Linter
+import pkg_resources
 
 def link_asset_message(link_list:list, type: str, format: str):
     if len(link_list) > 0:
@@ -126,7 +127,7 @@ def cli_message(linter):
 )
 @click.command()
 @click.argument('file')
-@click.version_option(version="1.2.0")
+@click.version_option(version=pkg_resources.require("stac-check")[0].version)
 def main(file, recursive, assets, links):
     linter = Linter(file, assets=assets, links=links, recursive=recursive)
     intro_message(linter)

--- a/stac_check/cli.py
+++ b/stac_check/cli.py
@@ -13,6 +13,7 @@ def link_asset_message(link_list:list, type: str, format: str):
 def recursive_message(linter):
     click.secho()
     click.secho(f"Recursive: Validate all assets in a collection or catalog", bold=True)
+    click.secho(f"Max-depth = {linter.max_depth}")
     click.secho("-------------------------")
     for count, msg in enumerate(linter.validate_all):
         click.secho(f"Asset {count+1} Validated: {msg['path']}", bg="white", fg="black")
@@ -115,9 +116,14 @@ def cli_message(linter):
 @click.option(
     "--recursive",
     "-r",
+    is_flag=True,
+    help="Recursively validate all related stac objects.",
+)
+@click.option(
+    "--max-depth",
+    "-m",
     type=int,
-    default=0,
-    help="Maximum depth to traverse when using recursion.",
+    help="Maximum depth to traverse when recursing. Omit this argument to get full recursion. Ignored if `recursive == False`.",
 )
 @click.option(
     "-a", "--assets", is_flag=True, help="Validate assets for format and response."
@@ -128,8 +134,8 @@ def cli_message(linter):
 @click.command()
 @click.argument('file')
 @click.version_option(version=pkg_resources.require("stac-check")[0].version)
-def main(file, recursive, assets, links):
-    linter = Linter(file, assets=assets, links=links, recursive=recursive)
+def main(file, recursive, max_depth, assets, links):
+    linter = Linter(file, assets=assets, links=links, recursive=recursive, max_depth=max_depth)
     intro_message(linter)
     if recursive > 0:
         recursive_message(linter)

--- a/stac_check/cli.py
+++ b/stac_check/cli.py
@@ -78,7 +78,7 @@ def cli_message(linter):
     if linter.validate_all == True:
         click.secho()
         click.secho(f"Recursive validation has passed!", fg='blue')
-    elif linter.validate_all == False and linter.recursive > 0:
+    elif linter.validate_all == False and linter.recursive:
         click.secho()
         click.secho(f"Recursive validation has failed!", fg='red')
 

--- a/stac_check/cli.py
+++ b/stac_check/cli.py
@@ -32,7 +32,8 @@ def cli_message(linter):
 
     if linter.recursive > 0:
         click.secho(f"    Recursive: Validate all assets in a collection or catalog")
-        click.secho(f"    Assets Validated: ")
+        click.secho()
+        click.secho(f"Assets Validated: ")
         click.secho()
         for msg in linter.validate_all:
             click.secho(f"Version {msg['version']}")
@@ -44,7 +45,11 @@ def cli_message(linter):
                 click.secho(f"Error Type {msg['error_type']}")
             if "error_message" in msg:
                 click.secho(f"Error Type {msg['error_message']}")
-            click.secho(f"Valid {msg['valid_stac']}")
+            click.echo("Valid: ")
+            if msg['valid_stac'] == True:
+                click.secho(f"{msg['valid_stac']}", fg='green')
+            else:
+                click.secho(f"{msg['valid_stac']}", fg='red')
             click.secho()
 
     else:

--- a/stac_check/cli.py
+++ b/stac_check/cli.py
@@ -38,7 +38,12 @@ def cli_message(linter):
             click.secho(f"Version {msg['version']}")
             click.secho(f"Path {msg['path']}")
             click.secho(f"Schemas {msg['schema']}")
-            click.secho(f"Type {msg['asset_type']}")
+            if "asset_type" in msg:
+                click.secho(f"Type {msg['asset_type']}")
+            if "error_type" in msg:
+                click.secho(f"Error Type {msg['error_type']}")
+            if "error_message" in msg:
+                click.secho(f"Error Type {msg['error_message']}")
             click.secho(f"Valid {msg['valid_stac']}")
             click.secho()
 

--- a/stac_check/cli.py
+++ b/stac_check/cli.py
@@ -9,7 +9,29 @@ def link_asset_message(link_list:list, type: str, format: str):
     else:
         click.secho(f"No {type.upper()} {format} errors!", fg="green")
 
-def cli_message(linter):
+def recursive_message(linter):
+    click.secho(f"    Recursive: Validate all assets in a collection or catalog")
+    click.secho()
+    click.secho(f"Assets Validated: ")
+    click.secho()
+    for msg in linter.validate_all:
+        click.secho(f"Version {msg['version']}")
+        click.secho(f"Path {msg['path']}")
+        click.secho(f"Schemas {msg['schema']}")
+        if "asset_type" in msg:
+            click.secho(f"Type {msg['asset_type']}")
+        if "error_type" in msg:
+            click.secho(f"Error Type {msg['error_type']}")
+        if "error_message" in msg:
+            click.secho(f"Error Type {msg['error_message']}")
+        click.echo("Valid: ")
+        if msg['valid_stac'] == True:
+            click.secho(f"{msg['valid_stac']}", fg='green')
+        else:
+            click.secho(f"{msg['valid_stac']}", fg='red')
+        click.secho()
+
+def intro_message(linter):
     click.secho("""
  ____  ____  __    ___       ___  _  _  ____  ___  __ _ 
 / ___)(_  _)/ _\  / __)___  / __)/ )( \(  __)/ __)(  / )
@@ -30,86 +52,64 @@ def cli_message(linter):
 
     click.secho(f"Validator: stac-validator {linter.validator_version}", bg="blue", fg="white")
 
-    if linter.recursive > 0:
-        click.secho(f"    Recursive: Validate all assets in a collection or catalog")
-        click.secho()
-        click.secho(f"Assets Validated: ")
-        click.secho()
-        for msg in linter.validate_all:
-            click.secho(f"Version {msg['version']}")
-            click.secho(f"Path {msg['path']}")
-            click.secho(f"Schemas {msg['schema']}")
-            if "asset_type" in msg:
-                click.secho(f"Type {msg['asset_type']}")
-            if "error_type" in msg:
-                click.secho(f"Error Type {msg['error_type']}")
-            if "error_message" in msg:
-                click.secho(f"Error Type {msg['error_message']}")
-            click.echo("Valid: ")
-            if msg['valid_stac'] == True:
-                click.secho(f"{msg['valid_stac']}", fg='green')
-            else:
-                click.secho(f"{msg['valid_stac']}", fg='red')
-            click.secho()
+    click.secho()
 
+def cli_message(linter):
+    ''' valid stac object message - true or false '''
+    if linter.valid_stac == True:
+        click.secho(f"Valid {linter.asset_type}: {linter.valid_stac}", fg='green')
     else:
-        click.secho()
-        
-        ''' valid stac object message - true or false '''
-        if linter.valid_stac == True:
-            click.secho(f"Valid {linter.asset_type}: {linter.valid_stac}", fg='green')
+        click.secho(f"Valid {linter.asset_type}: {linter.valid_stac}", fg='red')
+
+    ''' schemas validated for core object '''
+    click.secho()
+    if len(linter.schema) > 0:
+        click.secho("Schemas validated: ", fg="blue")
+        for schema in linter.schema:
+            click.secho(f"    {schema}")
+
+    ''' best practices message'''
+    click.secho()
+    for message in linter.best_practices_msg:
+        if message == linter.best_practices_msg[0]:
+            click.secho(message, bg='blue')
         else:
-            click.secho(f"Valid {linter.asset_type}: {linter.valid_stac}", fg='red')
+            click.secho(message, fg='red')
 
-        ''' schemas validated for core object '''
+    if linter.validate_all == True:
         click.secho()
-        if len(linter.schema) > 0:
-            click.secho("Schemas validated: ", fg="blue")
-            for schema in linter.schema:
-                click.secho(f"    {schema}")
-
-        ''' best practices message'''
+        click.secho(f"Recursive validation has passed!", fg='blue')
+    elif linter.validate_all == False and linter.recursive > 0:
         click.secho()
-        for message in linter.best_practices_msg:
-            if message == linter.best_practices_msg[0]:
-                click.secho(message, bg='blue')
-            else:
-                click.secho(message, fg='red')
+        click.secho(f"Recursive validation has failed!", fg='red')
 
-        if linter.validate_all == True:
-            click.secho()
-            click.secho(f"Recursive validation has passed!", fg='blue')
-        elif linter.validate_all == False and linter.recursive > 0:
-            click.secho()
-            click.secho(f"Recursive validation has failed!", fg='red')
-
-        if linter.invalid_asset_format is not None:
-            click.secho()
-            link_asset_message(linter.invalid_asset_format, "asset", "format")
-
-        if linter.invalid_asset_request is not None:
-            click.secho()
-            link_asset_message(linter.invalid_asset_request, "asset", "request")
-
-        if linter.invalid_link_format is not None:
-            click.secho()
-            link_asset_message(linter.invalid_link_format, "link", "format")
-
-        if linter.invalid_link_request is not None:
-            click.secho()
-            link_asset_message(linter.invalid_link_request, "link", "request")
-
-        if linter.error_type != "":
-            click.secho(f"Validation error type: ", fg="red")
-            click.secho(f"    {linter.error_type}")
-
-        if linter.error_msg != "":
-            click.secho(f"Validation error message: ", fg='red')
-            click.secho(f"    {linter.error_msg}")
-
+    if linter.invalid_asset_format is not None:
         click.secho()
+        link_asset_message(linter.invalid_asset_format, "asset", "format")
 
-        click.secho(f"This object has {len(linter.data['links'])} links")
+    if linter.invalid_asset_request is not None:
+        click.secho()
+        link_asset_message(linter.invalid_asset_request, "asset", "request")
+
+    if linter.invalid_link_format is not None:
+        click.secho()
+        link_asset_message(linter.invalid_link_format, "link", "format")
+
+    if linter.invalid_link_request is not None:
+        click.secho()
+        link_asset_message(linter.invalid_link_request, "link", "request")
+
+    if linter.error_type != "":
+        click.secho(f"Validation error type: ", fg="red")
+        click.secho(f"    {linter.error_type}")
+
+    if linter.error_msg != "":
+        click.secho(f"Validation error message: ", fg='red')
+        click.secho(f"    {linter.error_msg}")
+
+    click.secho()
+
+    click.secho(f"This object has {len(linter.data['links'])} links")
 
     click.secho()
 
@@ -134,4 +134,8 @@ def cli_message(linter):
 @click.version_option(version="1.2.0")
 def main(file, recursive, assets, links):
     linter = Linter(file, assets=assets, links=links, recursive=recursive)
-    cli_message(linter)
+    intro_message(linter)
+    if recursive > 0:
+        recursive_message(linter)
+    else:
+        cli_message(linter)

--- a/stac_check/cli.py
+++ b/stac_check/cli.py
@@ -10,26 +10,23 @@ def link_asset_message(link_list:list, type: str, format: str):
         click.secho(f"No {type.upper()} {format} errors!", fg="green")
 
 def recursive_message(linter):
-    click.secho(f"    Recursive: Validate all assets in a collection or catalog")
     click.secho()
-    click.secho(f"Assets Validated: ")
-    click.secho()
-    for msg in linter.validate_all:
-        click.secho(f"Version {msg['version']}")
-        click.secho(f"Path {msg['path']}")
-        click.secho(f"Schemas {msg['schema']}")
-        if "asset_type" in msg:
-            click.secho(f"Type {msg['asset_type']}")
-        if "error_type" in msg:
-            click.secho(f"Error Type {msg['error_type']}")
-        if "error_message" in msg:
-            click.secho(f"Error Type {msg['error_message']}")
-        click.echo("Valid: ")
-        if msg['valid_stac'] == True:
-            click.secho(f"{msg['valid_stac']}", fg='green')
-        else:
-            click.secho(f"{msg['valid_stac']}", fg='red')
+    click.secho(f"Recursive: Validate all assets in a collection or catalog", bold=True)
+    click.secho("-------------------------")
+    for count, msg in enumerate(linter.validate_all):
+        click.secho(f"Asset {count+1} Validated: {msg['path']}", bg="white", fg="black")
         click.secho()
+        if msg['valid_stac'] == True:
+            recursive_linter = Linter(msg["path"], recursive=0)
+            cli_message(recursive_linter)
+        else:
+            click.secho(f"Valid: {msg['valid_stac']}", fg='red')
+            click.secho("Schemas validated: ", fg="blue")
+            for schema in msg["schema"]:
+                click.secho(f"    {schema}")
+            click.secho(f"Error Type: {msg['error_type']}", fg='red')
+            click.secho(f"Error Message: {msg['error_message']}", fg='red')
+        click.secho("-------------------------")
 
 def intro_message(linter):
     click.secho("""
@@ -106,8 +103,6 @@ def cli_message(linter):
     if linter.error_msg != "":
         click.secho(f"Validation error message: ", fg='red')
         click.secho(f"    {linter.error_msg}")
-
-    click.secho()
 
     click.secho(f"This object has {len(linter.data['links'])} links")
 

--- a/stac_check/cli.py
+++ b/stac_check/cli.py
@@ -28,74 +28,78 @@ def cli_message(linter):
 
     click.secho()
 
-    ''' validator used - pystac if recursive otherwise stac-validator '''
-    if linter.recursive == True:
-        click.secho(f"Validator: pystac 1.1.0", bg="blue", fg="white")
+    click.secho(f"Validator: stac-validator {linter.validator_version}", bg="blue", fg="white")
+
+    if linter.recursive > 0:
         click.secho(f"    Recursive: Validate all assets in a collection or catalog")
+        click.secho(f"    Assets Validated: ")
+        click.secho()
+        for msg in linter.validate_all:
+            click.secho(f"Version {msg['version']}")
+            click.secho(f"Path {msg['path']}")
+            click.secho(f"Schemas {msg['schema']}")
+            click.secho(f"Type {msg['asset_type']}")
+            click.secho(f"Valid {msg['valid_stac']}")
+            click.secho()
+
     else:
-        click.secho(f"Validator: stac-validator {linter.validator_version}", bg="blue", fg="white")
-
-    click.secho()
-    
-    ''' valid stac object message - true or false '''
-    if linter.valid_stac == True:
-        click.secho(f"Valid {linter.asset_type}: {linter.valid_stac}", fg='green')
-    else:
-        click.secho(f"Valid {linter.asset_type}: {linter.valid_stac}", fg='red')
-
-    ''' schemas validated for core object '''
-    click.secho()
-    if len(linter.schema) > 0:
-        click.secho("Schemas validated: ", fg="blue")
-        for schema in linter.schema:
-            click.secho(f"    {schema}")
-
-    ''' best practices message'''
-    click.secho()
-    for message in linter.best_practices_msg:
-        if message == linter.best_practices_msg[0]:
-            click.secho(message, bg='blue')
+        click.secho()
+        
+        ''' valid stac object message - true or false '''
+        if linter.valid_stac == True:
+            click.secho(f"Valid {linter.asset_type}: {linter.valid_stac}", fg='green')
         else:
-            click.secho(message, fg='red')
+            click.secho(f"Valid {linter.asset_type}: {linter.valid_stac}", fg='red')
 
-    if linter.validate_all == True:
+        ''' schemas validated for core object '''
         click.secho()
-        click.secho(f"Recursive validation has passed!", fg='blue')
-    elif linter.validate_all == False and linter.recursive == True:
+        if len(linter.schema) > 0:
+            click.secho("Schemas validated: ", fg="blue")
+            for schema in linter.schema:
+                click.secho(f"    {schema}")
+
+        ''' best practices message'''
         click.secho()
-        click.secho(f"Recursive validation has failed!", fg='red')
+        for message in linter.best_practices_msg:
+            if message == linter.best_practices_msg[0]:
+                click.secho(message, bg='blue')
+            else:
+                click.secho(message, fg='red')
 
-    if linter.invalid_asset_format is not None:
+        if linter.validate_all == True:
+            click.secho()
+            click.secho(f"Recursive validation has passed!", fg='blue')
+        elif linter.validate_all == False and linter.recursive > 0:
+            click.secho()
+            click.secho(f"Recursive validation has failed!", fg='red')
+
+        if linter.invalid_asset_format is not None:
+            click.secho()
+            link_asset_message(linter.invalid_asset_format, "asset", "format")
+
+        if linter.invalid_asset_request is not None:
+            click.secho()
+            link_asset_message(linter.invalid_asset_request, "asset", "request")
+
+        if linter.invalid_link_format is not None:
+            click.secho()
+            link_asset_message(linter.invalid_link_format, "link", "format")
+
+        if linter.invalid_link_request is not None:
+            click.secho()
+            link_asset_message(linter.invalid_link_request, "link", "request")
+
+        if linter.error_type != "":
+            click.secho(f"Validation error type: ", fg="red")
+            click.secho(f"    {linter.error_type}")
+
+        if linter.error_msg != "":
+            click.secho(f"Validation error message: ", fg='red')
+            click.secho(f"    {linter.error_msg}")
+
         click.secho()
-        link_asset_message(linter.invalid_asset_format, "asset", "format")
 
-    if linter.invalid_asset_request is not None:
-        click.secho()
-        link_asset_message(linter.invalid_asset_request, "asset", "request")
-
-    if linter.invalid_link_format is not None:
-        click.secho()
-        link_asset_message(linter.invalid_link_format, "link", "format")
-
-    if linter.invalid_link_request is not None:
-        click.secho()
-        link_asset_message(linter.invalid_link_request, "link", "request")
-
-    if linter.error_type != "":
-        click.secho(f"Validation error type: ", fg="red")
-        click.secho(f"    {linter.error_type}")
-
-    if linter.error_msg != "":
-        click.secho(f"Validation error message: ", fg='red')
-        click.secho(f"    {linter.error_msg}")
-
-    if linter.recursive_error_msg != "":
-        click.secho(f"Recursive validation error message: ", fg='red')
-        click.secho(f"    {linter.recursive_error_msg}")
-
-    click.secho()
-
-    click.secho(f"This object has {len(linter.data['links'])} links")
+        click.secho(f"This object has {len(linter.data['links'])} links")
 
     click.secho()
 
@@ -103,7 +107,11 @@ def cli_message(linter):
     # click.secho(json.dumps(linter.message, indent=4))
 
 @click.option(
-    "-r", "--recursive", is_flag=True, help="Validate all assets in a collection or catalog."
+    "--recursive",
+    "-r",
+    type=int,
+    default=0,
+    help="Maximum depth to traverse when using recursion.",
 )
 @click.option(
     "-a", "--assets", is_flag=True, help="Validate assets for format and response."
@@ -114,6 +122,6 @@ def cli_message(linter):
 @click.command()
 @click.argument('file')
 @click.version_option(version="1.2.0")
-def main(file, assets, links, recursive):
-    linter = Linter(file, assets, links, recursive)
+def main(file, recursive, assets, links):
+    linter = Linter(file, assets=assets, links=links, recursive=recursive)
     cli_message(linter)

--- a/stac_check/lint.py
+++ b/stac_check/lint.py
@@ -71,10 +71,11 @@ class Linter:
 
     def recursive_validation(self, file):
         if self.recursive > 0:
-            stac = StacValidate(file)
+            stac = StacValidate(file, recursive=True, max_depth=self.recursive)
             stac.run()
+            print(stac.message)
             return stac.message
-            
+
     def set_update_message(self):
         if self.version != "1.0.0":
             return f"Please upgrade from version {self.version} to version 1.0.0!"

--- a/stac_check/lint.py
+++ b/stac_check/lint.py
@@ -73,7 +73,6 @@ class Linter:
         if self.recursive > 0:
             stac = StacValidate(file, recursive=True, max_depth=self.recursive)
             stac.run()
-            print(stac.message)
             return stac.message
 
     def set_update_message(self):

--- a/stac_check/lint.py
+++ b/stac_check/lint.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 import requests
 from typing import Optional
 from dotenv import load_dotenv
+import pkg_resources
 
 load_dotenv()
 
@@ -25,7 +26,7 @@ class Linter:
         self.config = self.parse_config(self.config_file)
         self.asset_type = self.message["asset_type"] if "asset_type" in self.message else ""
         self.version = self.message["version"] if "version" in self.message else ""
-        self.validator_version = "3.0.0"
+        self.validator_version = pkg_resources.require("stac-validator")[0].version
         self.validate_all = self.recursive_validation(self.item)
         self.valid_stac = self.message["valid_stac"]
         self.error_type = self.check_error_type()

--- a/stac_check/lint.py
+++ b/stac_check/lint.py
@@ -18,7 +18,8 @@ class Linter:
     config_file: Optional[str] = None
     assets: bool = False
     links: bool = False
-    recursive: int = 0
+    recursive: bool = False
+    max_depth: Optional[int] = None
 
     def __post_init__(self):
         self.data = self.load_data(self.item)
@@ -71,8 +72,8 @@ class Linter:
         return stac.message[0]
 
     def recursive_validation(self, file):
-        if self.recursive > 0:
-            stac = StacValidate(file, recursive=True, max_depth=self.recursive)
+        if self.recursive:
+            stac = StacValidate(file, recursive=True, max_depth=self.max_depth)
             stac.run()
             return stac.message
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -2,6 +2,7 @@ from re import L
 from stac_check.lint import Linter
 import pytest
 
+@pytest.mark.skip(reason="test is ineffective - bad links are redirecting to a third party site")
 def test_linter_bad_asset_requests():
     file = "sample_files/1.0.0/core-item.json"
     linter = Linter(file, assets=True)
@@ -21,8 +22,7 @@ def test_linter_bad_assets():
         "https:/storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg"
     ]
     asset_request_errors = [
-        "https:/storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg",
-        "http://cool-sat.com/catalog/20201211_223832_CS2/20201211_223832_CS2.EPH"
+        "https:/storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg"
     ]
     assert linter.version == "1.0.0"
     assert linter.valid_stac == True
@@ -54,8 +54,7 @@ def test_linter_bad_links_assets():
         "https:/storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg"
     ]
     asset_request_errors = [
-        "https:/storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg",
-        "http://cool-sat.com/catalog/20201211_223832_CS2/20201211_223832_CS2.EPH"
+        "https:/storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg"
     ]
     link_format_errors = ["http:/remotdata.io/catalog/20201211_223832_CS2/index.html"]
     link_request_errors = [

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -108,28 +108,16 @@ def test_linter_collection_recursive():
     linter = Linter(file, assets=False, links=False, recursive=1000)
     assert linter.version == "1.0.0"
     assert linter.recursive == 1000
-    assert linter.validate_all == [
-        {
-            "version": "1.0.0",
-            "path": "sample_files/1.0.0/catalog-with-bad-item.json",
-            "schema": [
-                "https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json"
-            ],
-            "valid_stac": True,
-            "asset_type": "CATALOG",
-            "validation_method": "recursive"
-        },
-        {
-            "version": "1.0.0",
-            "path": "sample_files/1.0.0/./bad-item.json",
-            "schema": [
-                "https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json"
-            ],
-            "valid_stac": False,
-            "error_type": "FileNotFoundError",
-            "error_message": "[Errno 2] No such file or directory: 'sample_files/1.0.0/./bad-item.json'"
-        }
-    ]
+    assert linter.validate_all[0] == {
+        "version": "1.0.0",
+        "path": "sample_files/1.0.0/catalog-with-bad-item.json",
+        "schema": [
+            "https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json"
+        ],
+        "valid_stac": True,
+        "asset_type": "CATALOG",
+        "validation_method": "recursive"
+    }
 
 def test_linter_item_id_not_matching_file_name():
     file = "sample_files/1.0.0/core-item.json"

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -105,9 +105,9 @@ def test_linter_catalog():
 
 def test_linter_collection_recursive():
     file = "sample_files/1.0.0/catalog-with-bad-item.json"
-    linter = Linter(file, assets=False, links=False, recursive=1000)
+    linter = Linter(file, assets=False, links=False, recursive=True)
     assert linter.version == "1.0.0"
-    assert linter.recursive == 1000
+    assert linter.recursive == True
     assert linter.validate_all[0] == {
         "version": "1.0.0",
         "path": "sample_files/1.0.0/catalog-with-bad-item.json",
@@ -118,6 +118,92 @@ def test_linter_collection_recursive():
         "asset_type": "CATALOG",
         "validation_method": "recursive"
     }
+
+def test_linter_recursive_max_depth_4():
+    file = "https://radarstac.s3.amazonaws.com/stac/catalog.json"
+    stac = Linter(file, assets=False, links=False, recursive=True, max_depth=4)
+    assert stac.validate_all == [
+        {
+            "version": "0.7.0",
+            "path": "https://radarstac.s3.amazonaws.com/stac/catalog.json",
+            "schema": ["https://cdn.staclint.com/v0.7.0/catalog.json"],
+            "asset_type": "CATALOG",
+            "validation_method": "recursive",
+            "valid_stac": True,
+        },
+        {
+            "version": "0.7.0",
+            "path": "https://radarstac.s3.amazonaws.com/stac/radarsat-1/collection.json",
+            "schema": ["https://cdn.staclint.com/v0.7.0/collection.json"],
+            "asset_type": "COLLECTION",
+            "validation_method": "recursive",
+            "valid_stac": True,
+        },
+        {
+            "version": "0.7.0",
+            "path": "https://radarstac.s3.amazonaws.com/stac/radarsat-1/slc/catalog.json",
+            "schema": ["https://cdn.staclint.com/v0.7.0/catalog.json"],
+            "asset_type": "CATALOG",
+            "validation_method": "recursive",
+            "valid_stac": True,
+        },
+        {
+            "version": "0.7.0",
+            "path": "https://radarstac.s3.amazonaws.com/stac/radarsat-1/slc/2012-05-13/RS1_M0630938_F2N_20120513_225708_HH_SLC.json",
+            "schema": ["https://cdn.staclint.com/v0.7.0/item.json"],
+            "asset_type": "ITEM",
+            "validation_method": "recursive",
+            "valid_stac": True,
+        },
+        {
+            "version": "0.7.0",
+            "path": "https://radarstac.s3.amazonaws.com/stac/radarsat-1/slc/2012-06-14/RS1_M0634796_F3F_20120614_110317_HH_SLC.json",
+            "schema": ["https://cdn.staclint.com/v0.7.0/item.json"],
+            "asset_type": "ITEM",
+            "validation_method": "recursive",
+            "valid_stac": True,
+        },
+        {
+            "version": "0.7.0",
+            "path": "https://radarstac.s3.amazonaws.com/stac/radarsat-1/slc/2012-06-14/RS1_M0634795_F3F_20120614_110311_HH_SLC.json",
+            "schema": ["https://cdn.staclint.com/v0.7.0/item.json"],
+            "asset_type": "ITEM",
+            "validation_method": "recursive",
+            "valid_stac": True,
+        },
+        {
+            "version": "0.7.0",
+            "path": "https://radarstac.s3.amazonaws.com/stac/radarsat-1/slc/2012-10-12/RS1_M0634798_F3F_20121012_110325_HH_SLC.json",
+            "schema": ["https://cdn.staclint.com/v0.7.0/item.json"],
+            "asset_type": "ITEM",
+            "validation_method": "recursive",
+            "valid_stac": True,
+        },
+        {
+            "version": "0.7.0",
+            "path": "https://radarstac.s3.amazonaws.com/stac/radarsat-1/slc/2012-10-12/RS1_M0634799_F3F_20121012_110331_HH_SLC.json",
+            "schema": ["https://cdn.staclint.com/v0.7.0/item.json"],
+            "asset_type": "ITEM",
+            "validation_method": "recursive",
+            "valid_stac": True,
+        },
+        {
+            "version": "0.7.0",
+            "path": "https://radarstac.s3.amazonaws.com/stac/radarsat-1/raw/catalog.json",
+            "schema": ["https://cdn.staclint.com/v0.7.0/catalog.json"],
+            "asset_type": "CATALOG",
+            "validation_method": "recursive",
+            "valid_stac": True,
+        },
+        {
+            "version": "0.7.0",
+            "path": "https://radarstac.s3.amazonaws.com/stac/radarsat-1/raw/2012-05-13/RS1_M0000676_F2N_20120513_225701_HH_RAW.json",
+            "schema": ["https://cdn.staclint.com/v0.7.0/item.json"],
+            "asset_type": "ITEM",
+            "validation_method": "recursive",
+            "valid_stac": True,
+        },
+    ]
 
 def test_linter_item_id_not_matching_file_name():
     file = "sample_files/1.0.0/core-item.json"

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -103,12 +103,33 @@ def test_linter_catalog():
     assert linter.asset_type == "CATALOG"
     assert linter.check_bloated_links() == False
 
-def test_linter_collection_recursive_remote():
-    file = "https://raw.githubusercontent.com/stac-utils/pystac/main/tests/data-files/examples/0.9.0/collection-spec/examples/landsat-collection.json"
-    linter = Linter(file, assets=False, links=False, recursive=True)
-    assert linter.version == "0.9.0"
-    assert linter.recursive == True
-    assert linter.recursive_error_msg == "Exception Could not read uri https://landsat-stac.s3.amazonaws.com/landsat-8-l1/paths/catalog.json"
+def test_linter_collection_recursive():
+    file = "sample_files/1.0.0/catalog-with-bad-item.json"
+    linter = Linter(file, assets=False, links=False, recursive=1000)
+    assert linter.version == "1.0.0"
+    assert linter.recursive == 1000
+    assert linter.validate_all == [
+        {
+            "version": "1.0.0",
+            "path": "sample_files/1.0.0/catalog-with-bad-item.json",
+            "schema": [
+                "https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json"
+            ],
+            "valid_stac": True,
+            "asset_type": "CATALOG",
+            "validation_method": "recursive"
+        },
+        {
+            "version": "1.0.0",
+            "path": "sample_files/1.0.0/./bad-item.json",
+            "schema": [
+                "https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json"
+            ],
+            "valid_stac": False,
+            "error_type": "FileNotFoundError",
+            "error_message": "[Errno 2] No such file or directory: 'sample_files/1.0.0/./bad-item.json'"
+        }
+    ]
 
 def test_linter_item_id_not_matching_file_name():
     file = "sample_files/1.0.0/core-item.json"
@@ -172,4 +193,3 @@ def test_self_in_links():
     linter = Linter(file)
 
     assert linter.check_links_self() == False
-    

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -119,6 +119,20 @@ def test_linter_collection_recursive():
         "validation_method": "recursive"
     }
 
+def test_linter_recursive_max_depth_1():
+    file = "https://radarstac.s3.amazonaws.com/stac/catalog.json"
+    stac = Linter(file, assets=False, links=False, recursive=True, max_depth=1)
+    assert stac.validate_all == [
+        {
+            "version": "0.7.0",
+            "path": "https://radarstac.s3.amazonaws.com/stac/catalog.json",
+            "schema": ["https://cdn.staclint.com/v0.7.0/catalog.json"],
+            "asset_type": "CATALOG",
+            "validation_method": "recursive",
+            "valid_stac": True,
+        }
+    ]
+
 def test_linter_recursive_max_depth_4():
     file = "https://radarstac.s3.amazonaws.com/stac/catalog.json"
     stac = Linter(file, assets=False, links=False, recursive=True, max_depth=4)


### PR DESCRIPTION
This swaps out pystac to use stac-validator for recursion instead. It also adds functionality to lint recursively.

https://github.com/stac-utils/stac-check/issues/82

https://github.com/stac-utils/stac-check/issues/85