### PR TITLE
v1.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]  
+## Unreleased
+
+## [v1.3.1] - 2022-10-05
+## Changed
+- Changed pin on stac-validator to >=3.1.0 from ==3.2.0 
      
 ## [v1.3.0] - 2022-09-20
 ### Added
@@ -83,6 +87,7 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 - Links and assets validation checks     
   
 [Unreleased]: https://github.com/stac-utils/stac-check/compare/v1.3.0...main  
+[v1.3.1]: https://github.com/stac-utils/stac-check/compare/v1.3.0...v1.3.1 
 [v1.3.0]: https://github.com/stac-utils/stac-check/compare/v1.2.0...v1.3.0  
 [v1.2.0]: https://github.com/stac-utils/stac-check/compare/v1.1.2...v1.2.0  
 [v1.1.2]: https://github.com/stac-utils/stac-check/compare/v1.0.1...v1.1.2  

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 """
 from setuptools import setup, find_packages
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
Update stac-check to v1.3.1. The reason for this release is that the pin on stac-validator haas changed from `==3.2.0` to `>=3.1.0`

https://github.com/stac-utils/stac-check/issues/88