### PR TITLE
Use a released version of jsonschema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     install_requires=[
         "click>=8.0.0",
         "requests>=2.19.1",
-        "jsonschema>=3.1.2b0",
+        "jsonschema>=3.1.2",
         "pytest",
         "stac-validator>=3.1.0",
         "PyYAML",


### PR DESCRIPTION
I _think_ this is causing us to pick up an alpha version of jsonschema in downstreams, which is causing hard-to-track down breakages.

IMO, released versions of packages should depend on released versions of other packages when at all possible.

If possible, it'd be great to get a release (BUGFIX or otherwise) of **stac-check** after this is merged, so downstreams can pick up the dependency fix.

## Context

- jsonschema put out an alpha release of 4.18 that considered empty fragments invalid: https://github.com/python-jsonschema/jsonschema/issues/1064#issuecomment-1478404924
- Some of the STAC schemas (e.g. https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json) have empty fragments
- Because **stac-check** depends on a beta **jsonschema** version, I _think_ this was turning on pre-release installs for any resolution of **jsonschema** dependencies: https://pip.pypa.io/en/stable/cli/pip_install/#pre-release-versions
- This broke validation checks in various CIs (e.g. https://github.com/stac-utils/stactools/actions/runs/4490766359/jobs/7900073955?pr=405) because if **stac-check** was in the enviornment, **jsonschema** could/would be installed as the alpha release