### PR TITLE
Split development dependencies from runtime dependencies

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9]
-    
+
     steps:
 
       - uses: actions/checkout@v2
@@ -30,5 +30,5 @@ jobs:
 
       - name: Run unit tests
         run: |
-          pip install .
+          pip install '.[dev]'
           pytest -v

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,23 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 
 ## Unreleased
 
+### Changed
+
+- Development dependencies removed from runtime dependency list
+  ([#109](https://github.com/stac-utils/stac-check/pull/109))
+
 ## [v1.3.2] - 2023-03-23
-## Added
+### Added
 - Ability to lint dictionaries https://github.com/stac-utils/stac-check/pull/94
 - Docstrings and pdoc api documents
-## Fixed
+### Fixed
 - Fixed the check_catalog_file_name() method to only work on static catalogs https://github.com/stac-utils/stac-check/pull/94
 - Jsonschema version to use a released version https://github.com/stac-utils/stac-check/pull/105
 
 ## [v1.3.1] - 2022-10-05
-## Changed
-- Changed pin on stac-validator to >=3.1.0 from ==3.2.0 
-     
+### Changed
+- Changed pin on stac-validator to >=3.1.0 from ==3.2.0
+
 ## [v1.3.0] - 2022-09-20
 ### Added
 - recursive mode lints assets https://github.com/stac-utils/stac-check/pull/84
@@ -39,7 +44,7 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 - Make it easier to export linting messages
 - Set stac-validator version to 2.4.0
 ### Fixed
-- Fix self-link test 
+- Fix self-link test
 
 ## [v1.0.1] - 2022-02-20
 ### Changed
@@ -61,7 +66,7 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 - Check for bloated metadata, too many fields in properties
 - Check for geometry field, recommend that STAC not be used for non-spatial data
 
-### Changed  
+### Changed
 - Changed bloated links check to a boolean to mirror bloated metadata
 
 ## [v0.1.2] - 2022-01-17 - 2022-01-22
@@ -70,19 +75,19 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 - Check for unlocated items, bbox should be set to null if geometry is
 
 ## [v0.1.1] - 2021-11-26 - 2021-12-12
-### Added  
+### Added
 - Added github actions to test and push to pypi
-- Added makefile, dockerfile  
+- Added makefile, dockerfile
 
-### Changed  
-- Removed pipenv  
+### Changed
+- Removed pipenv
 
 ## [v0.1.0] - 2021-11-26 - 2021-12-05
 ### Added
 - Best practices - searchable identifiers - lowercase, numbers, '_' or '-'
   for id names
   https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#searchable-identifiers
-- Best practices ensure item ids don't contain ':' or '/' characters  
+- Best practices ensure item ids don't contain ':' or '/' characters
   https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#item-ids
 - Best practices check for item ids to see if they match file names
 - Add url support, check for valid urls, validate urls
@@ -91,18 +96,18 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 - Move stac-validator 2.3.0 into repository
 - Best practices check for too many links in object
 - Best practices check for summaries in collections
-- Validation from stac-validator 2.3.0  
-- Links and assets validation checks     
-  
-[Unreleased]: https://github.com/stac-utils/stac-check/compare/v1.3.2...main  
-[v1.3.2]: https://github.com/stac-utils/stac-check/compare/v1.3.1...v1.3.2 
-[v1.3.1]: https://github.com/stac-utils/stac-check/compare/v1.3.0...v1.3.1 
-[v1.3.0]: https://github.com/stac-utils/stac-check/compare/v1.2.0...v1.3.0  
-[v1.2.0]: https://github.com/stac-utils/stac-check/compare/v1.1.2...v1.2.0  
-[v1.1.2]: https://github.com/stac-utils/stac-check/compare/v1.0.1...v1.1.2  
-[v1.0.1]: https://github.com/stac-utils/stac-check/compare/v0.2.0...v1.0.1  
-[v0.2.0]: https://github.com/stac-utils/stac-check/compare/v0.1.3...v0.2.0  
-[v0.1.3]: https://github.com/stac-utils/stac-check/compare/v0.1.2...v0.1.3  
-[v0.1.2]: https://github.com/stac-utils/stac-check/compare/v0.1.1...v0.1.2  
-[v0.1.1]: https://github.com/stac-utils/stac-check/compare/v0.1.0...v0.1.1  
-[v0.1.0]: https://github.com/stac-utils/stac-check/releases/tag/v0.1.0  
+- Validation from stac-validator 2.3.0
+- Links and assets validation checks
+
+[Unreleased]: https://github.com/stac-utils/stac-check/compare/v1.3.2...main
+[v1.3.2]: https://github.com/stac-utils/stac-check/compare/v1.3.1...v1.3.2
+[v1.3.1]: https://github.com/stac-utils/stac-check/compare/v1.3.0...v1.3.1
+[v1.3.0]: https://github.com/stac-utils/stac-check/compare/v1.2.0...v1.3.0
+[v1.2.0]: https://github.com/stac-utils/stac-check/compare/v1.1.2...v1.2.0
+[v1.1.2]: https://github.com/stac-utils/stac-check/compare/v1.0.1...v1.1.2
+[v1.0.1]: https://github.com/stac-utils/stac-check/compare/v0.2.0...v1.0.1
+[v0.2.0]: https://github.com/stac-utils/stac-check/compare/v0.1.3...v0.2.0
+[v0.1.3]: https://github.com/stac-utils/stac-check/compare/v0.1.2...v0.1.3
+[v0.1.2]: https://github.com/stac-utils/stac-check/compare/v0.1.1...v0.1.2
+[v0.1.1]: https://github.com/stac-utils/stac-check/compare/v0.1.0...v0.1.1
+[v0.1.0]: https://github.com/stac-utils/stac-check/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ The intent of this project is to provide a validation tool that also follows the
 
 ---
 ### Install
-`$ pip install stac-check`   
-  
-or for local development   
+`$ pip install stac-check`
 
-`$ pip install -e .` 
-  
+or for local development
+
+`$ pip install -e '.[dev]'`
+
 ---
 ### CLI Usage
 ```
@@ -31,10 +31,10 @@ Options:
   --help                   Show this message and exit.               Show this message and exit.
 ```
 ---
-### Docker  
+### Docker
 
 ```
-$ make build  
+$ make build
 $ make shell
 ```
 ---
@@ -50,14 +50,14 @@ for k, v in linter.create_best_practices_dict().items():
 ```
 ---
 ### CLI Examples
-    
+
 ``` stac-check https://raw.githubusercontent.com/stac-utils/pystac/main/tests/data-files/examples/0.9.0/collection-spec/examples/landsat-collection.json --recursive ```
 ```
- ____  ____  __    ___       ___  _  _  ____  ___  __ _ 
+ ____  ____  __    ___       ___  _  _  ____  ___  __ _
 / ___)(_  _)/ _\  / __)___  / __)/ )( \(  __)/ __)(  / )
-\___ \  )( /    \( (__(___)( (__ ) __ ( ) _)( (__  )  ( 
+\___ \  )( /    \( (__(___)( (__ ) __ ( ) _)( (__  )  (
 (____/ (__)\_/\_/ \___)     \___)\_)(_/(____)\___)(__\_)
-    
+
 stac-check: STAC spec validaton and linting tool
 
 Please upgrade from version 0.9.0 to version 1.0.0!
@@ -72,10 +72,10 @@ Asset 1 Validated: https://raw.githubusercontent.com/stac-utils/pystac/main/test
 
 Valid COLLECTION: True
 
-Schemas validated: 
+Schemas validated:
     https://cdn.staclint.com/v0.9.0/collection.json
 
-STAC Best Practices: 
+STAC Best Practices:
     Object should be called 'collection.json' not 'landsat-collection.json'
 
     A STAC collection should contain a summaries field
@@ -89,7 +89,7 @@ This object has 4 links
 Asset 2 Validated: https://landsat-stac.s3.amazonaws.com/landsat-8-l1/paths/catalog.json
 
 Valid: False
-Schemas validated: 
+Schemas validated:
     https://cdn.staclint.com/v0.9.0/collection.json
 Error Type: JSONDecodeError
 Error Message: Expecting value: line 1 column 1 (char 0)
@@ -106,12 +106,12 @@ Validator: stac-validator 2.3.0
 
 Valid ITEM: True
 
-Schemas validated: 
+Schemas validated:
     https://cdn.staclint.com/v0.9.0/extension/eo.json
     https://cdn.staclint.com/v0.9.0/extension/view.json
     https://cdn.staclint.com/v0.9.0/item.json
 
-STAC Best Practices: 
+STAC Best Practices:
     Item name 'LC81530252014153LGN00' should only contain Searchable identifiers
     Identifiers should consist of only lowercase characters, numbers, '_', and '-'
     https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#searchable-identifiers
@@ -124,7 +124,7 @@ STAC Best Practices:
 This object has 4 links
 </pre>
 
-``` stac-check sample_files/1.0.0/core-item.json --assets```    
+``` stac-check sample_files/1.0.0/core-item.json --assets```
 <pre>
 <b>stac-check: STAC spec validaton and linting tool</b>
 
@@ -134,10 +134,10 @@ Validator: stac-validator 2.3.0
 
 Valid ITEM: True
 
-Schemas validated: 
+Schemas validated:
     https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json
 
-STAC Best Practices: 
+STAC Best Practices:
     Item name '20201211_223832_CS2' should only contain Searchable identifiers
     Identifiers should consist of only lowercase characters, numbers, '_', and '-'
     https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#searchable-identifiers
@@ -151,15 +151,15 @@ STAC Best Practices:
 
 No ASSET format errors!
 
-ASSET request errors: 
+ASSET request errors:
     http://cool-sat.com/catalog/20201211_223832_CS2/20201211_223832_CS2.EPH
 
 This object has 4 links
 </pre>
 
 
-   
-``` stac-check sample_files/1.0.0/core-item-bad-links.json --links --assets```    
+
+``` stac-check sample_files/1.0.0/core-item-bad-links.json --links --assets```
 <pre>
 <b>stac-check: STAC spec validaton and linting tool</b>
 
@@ -169,10 +169,10 @@ Validator: stac-validator 2.3.0
 
 Valid ITEM: True
 
-Schemas validated: 
+Schemas validated:
     https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json
 
-STAC Best Practices: 
+STAC Best Practices:
     Item name '20201211_223832_CS2' should only contain Searchable identifiers
     Identifiers should consist of only lowercase characters, numbers, '_', and '-'
     https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#searchable-identifiers
@@ -184,24 +184,24 @@ STAC Best Practices:
     A link to 'self' in links is strongly recommended
 
 
-ASSET format errors: 
+ASSET format errors:
     https:/storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg
 
-ASSET request errors: 
+ASSET request errors:
     https:/storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg
     http://cool-sat.com/catalog/20201211_223832_CS2/20201211_223832_CS2.EPH
 
-LINK format errors: 
+LINK format errors:
     http:/remotdata.io/catalog/20201211_223832_CS2/index.html
 
-LINK request errors: 
+LINK request errors:
     http://catalog/collection.json
     http:/remotdata.io/catalog/20201211_223832_CS2/index.html
 
 This object has 4 links
 </pre>
-  
-``` stac-check sample_files/0.9.0/bad-item.json```    
+
+``` stac-check sample_files/0.9.0/bad-item.json```
 <pre>
 <b>stac-check: STAC spec validaton and linting tool</b>
 
@@ -211,15 +211,15 @@ Validator: stac-validator 2.3.0
 
 Valid : False
 
-Schemas validated: 
+Schemas validated:
     https://cdn.staclint.com/v0.9.0/item.json
 
-STAC Best Practices: 
+STAC Best Practices:
     A link to 'self' in links is strongly recommended
 
-Validation error type: 
+Validation error type:
     ValidationError
-Validation error message: 
+Validation error message:
     'id' is a required property of the root of the STAC object
 
 This object has 5 links

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,16 @@ setup(
         "click>=8.0.0",
         "requests>=2.19.1",
         "jsonschema>=3.1.2",
-        "pytest",
         "stac-validator>=3.1.0",
         "PyYAML",
         "python-dotenv",
-        "types-setuptools",
     ],
+    extras_require={
+        "dev": [
+            "pytest",
+            "types-setuptools",
+        ],
+    },
     entry_points={
         'console_scripts': ['stac-check=stac_check.cli:main']
     },

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
     license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     tests_require=["pytest"]
 )


### PR DESCRIPTION
I was noticing that pytest was getting pulled in to a project's runtime dependencies per it's dependency on this package. Looking more closely at the code, it appears `types-setuptools` and `pytest` are not actual runtime dependencies of this package but development-only dependencies.

This PR is to split those two packages into a extra requirements set called `dev` so they aren't part of the runtime dependency set for this package.

Now, for local development, instead of running `pip install -e .`, one would run `pip install -e '.[dev]'`.