### PR TITLE
create validation summary for api linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 
 ## Unreleased
 
+## [v1.11.0] - 2025-06-22
+
+### Added
+
+- Results summary for options that produce numerous results, ie. --collections, --item-collection, --recursive ([#138](https://github.com/stac-utils/stac-check/pull/138))
+- Support for --verbose flag to show verbose results summary ([#138](https://github.com/stac-utils/stac-check/pull/138))
+- Added `--output`/`-o` option to save validation results to a file ([#139](https://github.com/stac-utils/stac-check/pull/139))
+
 ## [v1.10.1] - 2025-06-21
 
 ### Fixed
@@ -285,7 +293,8 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 - Validation from stac-validator 2.3.0
 - Links and assets validation checks
 
-[Unreleased]: https://github.com/stac-utils/stac-check/compare/v1.10.1...main
+[Unreleased]: https://github.com/stac-utils/stac-check/compare/v1.11.0...main
+[v1.11.0]: https://github.com/stac-utils/stac-check/compare/v1.10.1...v1.11.0
 [v1.10.1]: https://github.com/stac-utils/stac-check/compare/v1.10.0...v1.10.1
 [v1.10.0]: https://github.com/stac-utils/stac-check/compare/v1.9.1...v1.10.0
 [v1.9.1]: https://github.com/stac-utils/stac-check/compare/v1.9.0...v1.9.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 
 - Results summary for options that produce numerous results, ie. --collections, --item-collection, --recursive ([#138](https://github.com/stac-utils/stac-check/pull/138))
 - Support for --verbose flag to show verbose results summary ([#138](https://github.com/stac-utils/stac-check/pull/138))
-- Added `--output`/`-o` option to save validation results to a file ([#139](https://github.com/stac-utils/stac-check/pull/139))
+- Added `--output`/`-o` option to save validation results to a file ([#138](https://github.com/stac-utils/stac-check/pull/138))
+- Tests for CLI options ([#138](https://github.com/stac-utils/stac-check/pull/138))
 
 ## [v1.10.1] - 2025-06-21
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Options:
                            multiple times.
   --pydantic               Use stac-pydantic for enhanced validation with Pydantic models.
   --verbose                Show verbose error messages.
+  -o, --output FILE        Save output to the specified file.
   --item-collection        Validate item collection response. Can be combined with
                            --pages. Defaults to one page.
   --collections            Validate collections endpoint response. Can be combined with

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import find_packages, setup
 
-__version__ = "1.10.1"
+__version__ = "1.11.0"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/stac_check/api_lint.py
+++ b/stac_check/api_lint.py
@@ -37,11 +37,13 @@ class ApiLinter:
         object_list_key: str,
         pages: Optional[int] = 1,
         headers: Optional[Dict] = None,
+        verbose: bool = False,
     ):
         self.source = source
         self.object_list_key = object_list_key
         self.pages = pages if pages is not None else 1
         self.headers = headers or {}
+        self.verbose = verbose
         self.version = None
         self.validator_version = self._get_validator_version()
 
@@ -148,7 +150,7 @@ class ApiLinter:
         results_by_url = {}
         for obj, obj_url in self.iterate_objects():
             try:
-                linter = Linter(obj)
+                linter = Linter(obj, verbose=self.verbose)
                 msg = dict(linter.message)
                 msg["path"] = obj_url
                 msg["best_practices"] = linter.best_practices_msg

--- a/stac_check/cli.py
+++ b/stac_check/cli.py
@@ -116,7 +116,7 @@ def main(
         # If recursive validation is enabled, use recursive_message
         if recursive:
             # Pass the cli_message function to avoid circular imports
-            recursive_message(linter, cli_message_func=cli_message)
+            recursive_message(linter, cli_message_func=cli_message, verbose=verbose)
         else:
             # Otherwise, just display the standard CLI message
             cli_message(linter)
@@ -133,13 +133,16 @@ def main(
             object_list_key=object_list_key,
             pages=pages,
             headers=dict(header),
+            verbose=verbose,
         )
         results = linter.lint_all()
         intro_message(linter)
         if collections:
-            collections_message(linter, results=results, cli_message_func=cli_message)
+            collections_message(
+                linter, results=results, cli_message_func=cli_message, verbose=verbose
+            )
         elif item_collection:
             item_collection_message(
-                linter, results=results, cli_message_func=cli_message
+                linter, results=results, cli_message_func=cli_message, verbose=verbose
             )
         sys.exit(0 if all(msg.get("valid_stac") is True for msg in results) else 1)

--- a/stac_check/display_messages.py
+++ b/stac_check/display_messages.py
@@ -216,40 +216,84 @@ def _display_disclaimer() -> None:
     click.secho()
 
 
-def _display_validation_summary(results: List[Dict[str, Any]]) -> None:
-    """Display a summary of validation results.
+def _display_validation_summary(
+    results: List[Dict[str, Any]], verbose: bool = False
+) -> None:
+    """Display a summary of validation results, including warnings and best practice issues.
 
     Args:
         results: List of validation result dictionaries
+        verbose: Whether to show detailed output
     """
     passed = 0
     failed = []
+    warnings = []
     all_paths = []
 
     for result in results:
         path = result.get("path", "unknown")
         all_paths.append(path)
+
+        # Check for validation status
         if result.get("valid_stac"):
             passed += 1
         else:
             failed.append(path)
 
-    click.secho("\n" + "=" * 50)
-    click.secho("VALIDATION SUMMARY", bold=True)
-    click.secho(f"Total assets checked: {len(all_paths)}")
-    click.secho(f"✅ Passed: {passed}")
+        # Check for best practice warnings in the result
+        best_practices = []
+        if result.get("best_practices"):
+            best_practices = [
+                p
+                for p in result["best_practices"]
+                if p and p.strip() and p != "STAC Best Practices: "
+            ]
+        # Also check for best practices in the message if it exists
+        elif (
+            result.get("message")
+            and isinstance(result["message"], dict)
+            and result["message"].get("best_practices")
+        ):
+            best_practices = [
+                p
+                for p in result["message"]["best_practices"]
+                if p and p.strip() and p != "STAC Best Practices: "
+            ]
+
+        # Only add to warnings if there are actual messages
+        if best_practices:
+            warnings.append((path, best_practices))
+
+    click.secho("\n Validation Summary", bold=True, bg="black", fg="white")
+    click.secho()
+    click.secho(f"✅ Passed: {passed}/{len(all_paths)}")
 
     if failed:
-        click.secho(f"❌ Failed: {len(failed)}", fg="red")
+        click.secho(f"❌ Failed: {len(failed)}/{len(all_paths)}", fg="red")
         click.secho("\nFailed Assets:", fg="red")
         for path in failed:
             click.secho(f"  - {path}")
 
-    click.secho("\nAll Assets Checked:")
-    for path in all_paths:
-        click.secho(f"  - {path}")
+    if warnings:
+        click.secho(
+            f"\n⚠️  Best Practice Warnings ({len(warnings)} assets)", fg="yellow"
+        )
+        if verbose or len(warnings) <= 12:
+            for path, msgs in warnings:
+                click.secho(f"\n  {path}:", fg="yellow")
+                for msg in msgs:
+                    click.secho(f"    • {msg}", fg="yellow")
+        else:
+            click.secho("  (Use --verbose to see details)", fg="yellow")
 
-    click.secho("\n" + "=" * 50)
+    click.secho(f"\n🔍 All {len(all_paths)} Assets Checked")
+    if verbose or len(all_paths) <= 12:
+        for path in all_paths:
+            click.secho(f"  - {path}")
+    else:
+        click.secho("  (Use --verbose to see all assets)", fg="yellow")
+
+    click.secho()
 
 
 def _display_validation_results(
@@ -258,6 +302,7 @@ def _display_validation_results(
     metadata: Optional[Dict[str, Any]] = None,
     cli_message_func: Optional[Callable[[Linter], None]] = None,
     create_linter_func: Optional[Callable[[Dict[str, Any]], Linter]] = None,
+    verbose: bool = False,
 ) -> None:
     """Shared helper function to display validation results consistently.
 
@@ -310,6 +355,20 @@ def _display_validation_results(
                         item_linter.error_type = msg.get("error_type")
                         item_linter.error_msg = msg.get("error_message")
 
+                    # Ensure best practices are included in the result
+                    if (
+                        hasattr(item_linter, "best_practices_msg")
+                        and item_linter.best_practices_msg
+                    ):
+                        # Skip the first line which is just the header
+                        bp_msgs = [
+                            msg
+                            for msg in item_linter.best_practices_msg[1:]
+                            if msg.strip()
+                        ]
+                        if bp_msgs:
+                            msg["best_practices"] = bp_msgs
+
                     # Display using the provided message function
                     cli_message_func(item_linter)
             else:
@@ -322,13 +381,14 @@ def _display_validation_results(
         click.secho("-------------------------")
 
     # Display summary at the end for better visibility with many items
-    _display_validation_summary(results)
+    _display_validation_summary(results, verbose=verbose)
 
 
 def item_collection_message(
     linter: ApiLinter,
     results: Optional[List[Dict[str, Any]]] = None,
     cli_message_func: Optional[Callable[[Linter], None]] = None,
+    verbose: bool = False,
 ) -> None:
     """Displays messages related to the validation of assets in a feature collection.
 
@@ -365,6 +425,7 @@ def item_collection_message(
         metadata={"Pages": linter.pages},
         cli_message_func=cli_message_func,
         create_linter_func=create_api_linter,
+        verbose=verbose,
     )
 
 
@@ -407,13 +468,17 @@ def _display_fallback_message(
 
     # Display best practices
     bp = msg.get("best_practices", [])
-    if bp and len(bp) > 0:
-        click.secho()
-        click.secho("\n STAC Best Practices: ", bg="blue")
-        click.secho()
+    # Filter out empty strings and the default "STAC Best Practices: " message
+    bp = [p for p in bp if p and p.strip() and p != "STAC Best Practices: "]
+
+    if bp:
+        click.echo()
+        click.secho("\nSTAC Best Practices: ", bg="blue")
+        click.echo()
         for practice in bp:
-            if practice:  # Skip empty strings
-                click.secho(practice, fg="black")
+            click.echo(f"    • {practice}", fg="black")
+        # Update the best_practices in the message for the summary
+        msg["best_practices"] = bp
 
     # Display geometry errors
     geo = msg.get("geometry_errors", [])
@@ -432,6 +497,7 @@ def collections_message(
     linter: ApiLinter,
     results: Optional[List[Dict[str, Any]]] = None,
     cli_message_func: Optional[Callable[[Linter], None]] = None,
+    verbose: bool = False,
 ) -> None:
     """Displays messages related to the validation of STAC collections from a collections endpoint.
 
@@ -468,11 +534,14 @@ def collections_message(
         metadata={"Pages": linter.pages},
         cli_message_func=cli_message_func,
         create_linter_func=create_collection_linter,
+        verbose=verbose,
     )
 
 
 def recursive_message(
-    linter: Linter, cli_message_func: Optional[Callable[[Linter], None]] = None
+    linter: Linter,
+    cli_message_func: Optional[Callable[[Linter], None]] = None,
+    verbose: bool = False,
 ) -> None:
     """Displays messages related to the recursive validation of assets in a collection or catalog.
 
@@ -504,6 +573,7 @@ def recursive_message(
         metadata={"Max-depth": linter.max_depth},
         cli_message_func=cli_message_func,
         create_linter_func=create_recursive_linter,
+        verbose=verbose,
     )
 
 

--- a/stac_check/utilities.py
+++ b/stac_check/utilities.py
@@ -1,3 +1,9 @@
+import contextlib
+from typing import Callable
+
+import click
+
+
 def determine_asset_type(data):
     """Determine the STAC asset type from the given data dictionary.
 
@@ -33,6 +39,32 @@ def determine_asset_type(data):
 
     # If we can't determine the type
     return ""
+
+
+def handle_output(
+    output_file: str, callback: Callable[[], None], output_path: str = None
+) -> None:
+    """Helper function to handle output redirection to a file or stdout.
+
+    Args:
+        output_file: Path to the output file, or None to use stdout
+        callback: Function that performs the actual output generation
+        output_path: Optional path to display in the success message
+    """
+
+    if output_file:
+        with open(output_file, "w") as f:
+            with contextlib.redirect_stdout(f):
+                callback()
+        click.secho(
+            f"Output written to {output_path or output_file}",
+            fg="green",
+            err=True,
+            bold=True,
+        )
+        click.secho()
+    else:
+        callback()
 
 
 def format_verbose_error(error_data):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,220 @@
+"""Tests for the stac-check CLI."""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from stac_check.cli import main as cli_main
+
+
+@pytest.fixture
+def runner():
+    """Fixture for invoking command-line interfaces."""
+    return CliRunner()
+
+
+def test_cli_help(runner):
+    """Test the CLI help output."""
+    result = runner.invoke(cli_main, ["--help"])
+    assert result.exit_code == 0
+    assert "Show this message and exit." in result.output
+
+
+def test_cli_version(runner):
+    """Test the --version flag."""
+    result = runner.invoke(cli_main, ["--version"])
+    assert result.exit_code == 0
+    # The version output is in the format: main, version X.Y.Z
+    assert "version" in result.output
+
+
+def test_cli_validate_local_file(runner):
+    """Test validating a local file."""
+    test_file = os.path.join(
+        os.path.dirname(__file__), "../sample_files/1.0.0/core-item.json"
+    )
+    result = runner.invoke(cli_main, [test_file])
+    assert result.exit_code == 0
+    assert "Passed: True" in result.output
+
+
+def test_cli_validate_recursive(runner):
+    """Test recursive validation."""
+    test_dir = os.path.join(
+        os.path.dirname(__file__), "../sample_files/1.0.0/catalog-with-bad-item.json"
+    )
+    result = runner.invoke(cli_main, [test_dir, "--recursive"])
+    assert result.exit_code == 0
+    assert "Assets Checked" in result.output
+
+
+def test_cli_output_to_file(runner):
+    """Test output to file with --output flag."""
+    test_file = os.path.join(
+        os.path.dirname(__file__), "../sample_files/1.0.0/core-item.json"
+    )
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        output_file = tmp.name
+
+    try:
+        result = runner.invoke(
+            cli_main, [test_file, "--recursive", "--output", output_file]
+        )
+        assert result.exit_code == 0
+        assert os.path.exists(output_file)
+        with open(output_file, "r") as f:
+            content = f.read()
+            assert "Passed: True" in content
+    finally:
+        if os.path.exists(output_file):
+            os.unlink(output_file)
+
+
+def test_cli_collections(runner):
+    """Test --collections flag with mock."""
+    with patch("stac_check.cli.ApiLinter") as mock_api_linter, patch(
+        "stac_check.cli.Linter"
+    ) as mock_linter:
+        # Mock ApiLinter instance
+        mock_api_instance = MagicMock()
+        mock_api_instance.lint_all.return_value = [{"valid_stac": True}]
+        mock_api_linter.return_value = mock_api_instance
+
+        # Mock Linter instance used for display
+        mock_linter_instance = MagicMock()
+        mock_linter.return_value = mock_linter_instance
+
+        result = runner.invoke(
+            cli_main,
+            ["https://example.com/collections", "--collections", "--pages", "1"],
+        )
+
+        assert result.exit_code == 0
+        mock_api_linter.assert_called_once_with(
+            source="https://example.com/collections",
+            object_list_key="collections",
+            pages=1,
+            headers={},
+            verbose=False,
+        )
+
+
+def test_cli_item_collection(runner):
+    """Test --item-collection flag with mock."""
+    with patch("stac_check.cli.ApiLinter") as mock_api_linter, patch(
+        "stac_check.cli.Linter"
+    ) as mock_linter:
+        # Mock ApiLinter instance
+        mock_api_instance = MagicMock()
+        mock_api_instance.lint_all.return_value = [{"valid_stac": True}]
+        mock_api_linter.return_value = mock_api_instance
+
+        # Mock Linter instance used for display
+        mock_linter_instance = MagicMock()
+        mock_linter.return_value = mock_linter_instance
+
+        result = runner.invoke(
+            cli_main, ["https://example.com/items", "--item-collection", "--pages", "2"]
+        )
+
+        assert result.exit_code == 0
+        mock_api_linter.assert_called_once_with(
+            source="https://example.com/items",
+            object_list_key="features",
+            pages=2,
+            headers={},
+            verbose=False,
+        )
+
+
+def test_cli_output_without_required_flags(runner):
+    """Test that --output requires --collections, --item-collection, or --recursive."""
+    with tempfile.NamedTemporaryFile() as tmp:
+        result = runner.invoke(
+            cli_main, ["https://example.com/catalog.json", "--output", tmp.name]
+        )
+        assert result.exit_code == 1
+        assert (
+            "--output can only be used with --collections, --item-collection, or --recursive"
+            in result.output
+        )
+
+
+def test_cli_verbose_flag(runner):
+    """Test that --verbose flag is passed correctly."""
+    with patch("stac_check.cli.Linter") as mock_linter:
+        mock_instance = MagicMock()
+        mock_linter.return_value = mock_instance
+
+        test_file = os.path.join(
+            os.path.dirname(__file__), "../sample_files/1.0.0/core-item.json"
+        )
+        result = runner.invoke(cli_main, [test_file, "--verbose"])
+
+        assert result.exit_code == 0
+        mock_linter.assert_called_once()
+        assert mock_linter.call_args[1]["verbose"] is True
+
+
+def test_cli_headers(runner):
+    """Test that custom headers are passed correctly."""
+    with patch("stac_check.cli.Linter") as mock_linter:
+        mock_instance = MagicMock()
+        mock_linter.return_value = mock_instance
+
+        test_file = os.path.join(
+            os.path.dirname(__file__), "../sample_files/1.0.0/core-item.json"
+        )
+        # The header format is: --header KEY VALUE (space-separated, not colon-separated)
+        result = runner.invoke(
+            cli_main,
+            [
+                test_file,
+                "--header",
+                "Authorization",
+                "Bearer token",
+                "--header",
+                "X-Custom",
+                "value",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_linter.assert_called_once()
+        # The headers should be passed as a dictionary to the Linter
+        headers = mock_linter.call_args[1]["headers"]
+        assert isinstance(headers, dict)
+        assert headers.get("Authorization") == "Bearer token"
+        assert headers.get("X-Custom") == "value"
+
+
+def test_cli_pydantic_flag(runner):
+    """Test that the --pydantic flag is passed correctly."""
+    with patch("stac_check.cli.Linter") as mock_linter, patch(
+        "stac_check.cli.importlib.import_module"
+    ):
+        mock_instance = MagicMock()
+        mock_linter.return_value = mock_instance
+
+        test_file = os.path.join(
+            os.path.dirname(__file__), "../sample_files/1.0.0/core-item.json"
+        )
+
+        # Test with --pydantic flag
+        result = runner.invoke(cli_main, [test_file, "--pydantic"])
+
+        assert result.exit_code == 0
+        mock_linter.assert_called_once()
+        # Check that pydantic=True was passed to Linter
+        assert mock_linter.call_args[1]["pydantic"] is True
+
+        # Test without --pydantic flag (should default to False)
+        mock_linter.reset_mock()
+        result = runner.invoke(cli_main, [test_file])
+
+        assert result.exit_code == 0
+        mock_linter.assert_called_once()
+        assert mock_linter.call_args[1]["pydantic"] is False


### PR DESCRIPTION
- Results summary for options that produce numerous results, ie. --collections, --item-collection, --recursive 
- Support for --verbose flag to show verbose results summary
- Added `--output`/`-o` option to save validation results to a file
- Tests for CLI options 